### PR TITLE
feat(ddo): add priority to support transclusion

### DIFF
--- a/src/angular-resizable.js
+++ b/src/angular-resizable.js
@@ -14,6 +14,7 @@ angular.module('angularResizable', [])
         }
         return {
             restrict: 'AE',
+            priority: 599, // right after ng-if. Supports transclusion
             scope: {
                 rDirections: '=',
                 rCenteredX: '=',


### PR DESCRIPTION
Adding this priority ensures that the grip will be appended after `ng-if` and after transclusion (in my case, the grip was not working with transclusion)
